### PR TITLE
Fix Markdown syntax for `ISSUE_TEMPLATE.md`

### DIFF
--- a/questions-answers/ISSUE_TEMPLATE.md
+++ b/questions-answers/ISSUE_TEMPLATE.md
@@ -19,4 +19,4 @@
 <!-- What should have happened? -->
 
 
-##Other Comments
+## Other Comments


### PR DESCRIPTION
For `questions-answers/ISSUE_TEMPLATE.md` templates.