### PR TITLE
Update README link in how to create issue template section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@
 
 # How to create issue templates?
 
-- [Creating issue templates for your repository](https://help.github.com/articles/creating-issue-templates-for-your-repository/)
+- [About issue and pull request templates](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates)
 - ~~[Manually creating a single issue template for your repository](https://help.github.com/articles/manually-creating-a-single-issue-template-for-your-repository/)~~
 
 # 10+ templates for you to pick!


### PR DESCRIPTION
The [Creating issue templates for your repository](https://help.github.com/en/articles/creating-issue-templates-for-your-repository) link in the README now leads to a 404 page.

This PR swaps out the dead link with the link that GitHub points to in the deprecation notice on the [Manually creating a single issue template for your repository](https://help.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository) page (which the stevemao/github-issue-templates README also links to).