### PR TITLE
feat(github-config): added a contribution & issues files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing
+
+## Request for changes/ Pull Requests
+You first need to create a fork of the [github-issue-template](https://github.com/stevemao/github-issue-templates/) repository to commit your changes to it. Methods to fork a repository can be found in the [GitHub Documentation](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+
+Then add your fork as a local project:
+
+```sh
+# Using HTTPS
+git clone https://github.com/stevemao/github-issue-templates.git
+
+# Using SSH
+git clone git@github.com:stevemao/github-issue-templates.git
+```
+
+> [Which remote URL should be used ?](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories)
+
+Then, go to your local folder
+
+```sh
+cd github-issue-template
+```
+
+Add git remote controls :
+
+```sh
+# Using HTTPS
+git remote add fork https://github.com/YOUR-USERNAME/github-issue-templates.git
+git remote add upstream https://github.com/stevemao/github-issue-templates.git
+
+
+# Using SSH
+git remote add fork git@github.com:YOUR-USERNAME/github-issue-templates.git
+git remote add upstream git@github.com/stevemao/github-issue-templates.git
+```
+
+You can now verify that you have your two git remotes:
+
+```sh
+git remote -v
+```
+
+## Receive remote updates
+In view of staying up to date with the central repository :
+
+```sh
+git pull upstream master
+```
+
+## Choose a base branch
+Before starting development, you need to know which branch to base your modifications/additions on. When in doubt, use master.
+
+| Type of change                |           | Branches              |
+| :------------------           |:---------:| ---------------------:|
+| Documentation                 |           | `master`              |
+| Bug fixes                     |           | `master`              |
+| New features                  |           | `master`              |
+| New issues models             |           | `YOUR-USERNAME:patch` |
+
+```sh
+# Switch to the desired branch
+git switch master
+
+# Pull down any upstream changes
+git pull
+
+# Create a new branch to work on
+git switch --create patch/1234-name-issue
+```
+
+Commit your changes, then push the branch to your fork with `git push -u fork` and open a pull request on [the Github-issue-templates repository](https://github.com/stevemao/github-issue-templates/) following the template provided.

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,80 @@
+name: "🐛 Bug Report"
+description: Create a new ticket for a bug.
+title: "🐛 [BUG] - <title>"
+labels: [
+  "bug"
+]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: Please enter an explicit description of your issue
+      placeholder: Short and explicit description of your incident...
+    validations:
+      required: true
+  - type: input
+    id: reprod-url
+    attributes:
+      label: "Reproduction URL"
+      description: Please enter your GitHub URL to provide a reproduction of the issue
+      placeholder: ex. https://github.com/USERNAME/REPO-NAME
+    validations:
+      required: true
+  - type: textarea
+    id: reprod
+    attributes:
+      label: "Reproduction steps"
+      description: Please enter an explicit description of your issue
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: "Screenshots"
+      description: If applicable, add screenshots to help explain your problem.
+      value: |
+        ![DESCRIPTION](LINK.png)
+      render: bash
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs"
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: bash
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: "Browsers"
+      description: What browsers are you seeing the problem on ?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+        - Opera
+    validations:
+      required: false
+  - type: dropdown
+    id: os
+    attributes:
+      label: "OS"
+      description: What is the impacted environment ?
+      multiple: true
+      options:
+        - Windows
+        - Linux
+        - Mac
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -1,0 +1,63 @@
+name: "💡 Feature Request"
+description: Create a new ticket for a new feature request
+title: "💡 [REQUEST] - <title>"
+labels: [
+  "question"
+]
+body:
+  - type: input
+    id: start_date
+    attributes:
+      label: "Start Date"
+      description: Start of development
+      placeholder: "month/day/year"
+    validations:
+      required: false
+  - type: textarea
+    id: implementation_pr
+    attributes:
+      label: "Implementation PR"
+      description: Pull request used
+      placeholder: "#Pull Request ID"
+    validations:
+      required: false
+  - type: textarea
+    id: reference_issues
+    attributes:
+      label: "Reference Issues"
+      description: Common issues
+      placeholder: "#Issues IDs"
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Summary"
+      description: Provide a brief explanation of the feature
+      placeholder: Describe in a few lines your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: basic_example
+    attributes:
+      label: "Basic Example"
+      description: Indicate here some basic examples of your feature.
+      placeholder: A few specific words about your feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: drawbacks
+    attributes:
+      label: "Drawbacks"
+      description: What are the drawbacks/impacts of your feature request ?
+      placeholder: Identify the drawbacks and impacts while being neutral on your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: unresolved_question
+    attributes:
+      label: "Unresolved questions"
+      description: What questions still remain unresolved ?
+      placeholder: Identify any unresolved issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "nuxt.isNuxtApp": false
+}


### PR DESCRIPTION
Hello to all, 

Considering that this project is of major importance to help us build our GitHub issue templates, I would like to propose the following additions in accordance with issue #25:

- [Contribution Guide](https://github.com/GregoireF/github-issue-templates/blob/docs/github/.github/CONTRIBUTING.md)
- [Bug report templates] taking advantage of [new GitHub templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).
- [Feature request] also taking advantage of [new GitHub templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).

I apologize for my bad English, it is possible that some spelling corrections are necessary ?

Cheers